### PR TITLE
Fix unregistering of the addon.

### DIFF
--- a/ext_bootstrap.js
+++ b/ext_bootstrap.js
@@ -165,7 +165,7 @@ function shutdown(data, reason) {
   log("extension is shutting down");
 
   // Stop registering about:sync in new processes.
-  Services.ppmm.removeDelayedProcessScript(DATA_URI_REGISTER_ABOUT);
+  Services.ppmm.removeDelayedProcessScript("chrome://aboutsync/content/RegisterRedirector.js");
   // And unregister about:sync in any processes we've already loaded in.
   Services.ppmm.loadProcessScript("chrome://aboutsync/content/UnregisterRedirector.js", true);
 


### PR DESCRIPTION
I previously moved away from a data: URL for registration because it
stopped working, but forgot to update the unregistration.