### PR TITLE
Revert requirement for 103 and add work-arounds for 102 and earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,15 @@ The general process followed by the addons team is
 but at the current time, the maintainers of about-sync don't have the required
 permissions. Therefore, the process is:
 
-* Get everything ready for the new release. Note that the addon version inside
-  manifest.json is not used by this process, so it's not strictly necessary
-  to bump it.
+* Consider bumping the version in `package.json` - that's not strictly necessary
+  as the final version string will be something like `X.Y.Zbuildid20220601.073719`,
+  but it makes it easier to work out what's in a version.
 
-* Ensure this revision is tested using the [testing process described above](#testing-a-xpi)
+* Find the exact github revision revision you want as the new build; usually current `main`.
+  Ensure this revision is tested using the [testing process described above](#testing-a-xpi)
 
 * Join the #addons-pipeline slack channel, asking for a release to be built
-  specifying the git revision - this will typically be `main`.
+  specifying that exact revision.
 
 * You should be given the link to a "release signing" taskcluster job - in this
   job, look for the built, signed .xpi and download it locally.

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
   "applications": {
     "gecko": {
       "id": "aboutsync@mhammond.github.com",
-      "strict_min_version": "103.0a1"
+      "strict_min_version": "72.0a1"
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aboutsync",
   "private": true,
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "About Sync Firefox addon",
   "scripts": {
     "build": "webpack --mode=production && web-ext build",

--- a/src/CollectionsViewer.jsx
+++ b/src/CollectionsViewer.jsx
@@ -93,8 +93,8 @@ const collectionComponentBuilders = {
   },
 
   async clients(provider, serverRecords) {
-    const { getFxAccountsSingleton } = importLocal("resource://gre/modules/FxAccounts.jsm");
-    const fxAccounts = getFxAccountsSingleton();
+    const { fxAccounts: legacyfxAccounts, getFxAccountsSingleton } = importLocal("resource://gre/modules/FxAccounts.jsm");
+    const fxAccounts = legacyfxAccounts || getFxAccountsSingleton();
     let fxaDevices = [];
     if (typeof fxAccounts.device == "object" && "recentDeviceList" in fxAccounts.device) {
       // Force a refresh of the device list, so that we always show the most

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -16,8 +16,8 @@ const weaveService = Cc["@mozilla.org/weave/service;1"]
                      .getService(Ci.nsISupports)
                      .wrappedJSObject;
 
-const { getFxAccountsSingleton } = importLocal("resource://gre/modules/FxAccounts.jsm");
-const fxAccounts = getFxAccountsSingleton();
+const { fxAccounts: legacyfxAccounts, getFxAccountsSingleton } = importLocal("resource://gre/modules/FxAccounts.jsm");
+const fxAccounts = legacyfxAccounts || getFxAccountsSingleton();
 
 // Returns a promise that resolves when Sync is ready and logged in.
 function whenSyncReady() {


### PR DESCRIPTION
As we discussed briefly in slack, I think the best thing to do for now is stick with supporting all versions.

I also discovered the version actually used is in `package.json`, which is why we've been on `0.19.0` 🤷 - so I bumped that to `0.20.0` while I'm at it.