### PR TITLE
Update areas using OS.File to the new IOUtils

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
   "applications": {
     "gecko": {
       "id": "aboutsync@mhammond.github.com",
-      "strict_min_version": "72.0a1"
+      "strict_min_version": "114.0a1"
     }
   },
 

--- a/src/CollectionsViewer.jsx
+++ b/src/CollectionsViewer.jsx
@@ -1,11 +1,9 @@
 const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 
 const React = require("react");
-const ReactDOM = require("react-dom");
-const DOM = require("react-dom-factories");
 const { TabView, TabPanel } = require("./TabView");
 
-const { Fetching, ObjectInspector, ErrorDisplay, arrayCloneWithoutJank, importLocal } = require("./common");
+const { Fetching, ObjectInspector, ErrorDisplay, arrayCloneWithoutJank } = require("./common");
 const { TableInspector } = require("./AboutSyncTableInspector");
 const { AboutSyncRecordEditor } = require("./AboutSyncRecordEditor");
 const { EngineActions } = require("./EngineActions");
@@ -15,10 +13,10 @@ const { BookmarkValidator } = require("./bookmarkValidator");
 
 const validation = require("./validation");
 
-const { Weave } = importLocal("resource://services-sync/main.js");
-const { AddonValidator } = importLocal("resource://services-sync/engines/addons.js");
-const { PasswordValidator } = importLocal("resource://services-sync/engines/passwords.js");
-const { FormValidator } = importLocal("resource://services-sync/engines/forms.js");
+const { Weave } = ChromeUtils.importESModule("resource://services-sync/main.sys.mjs");
+const { AddonValidator } = ChromeUtils.importESModule("resource://services-sync/engines/addons.sys.mjs");
+const { PasswordValidator } = ChromeUtils.importESModule("resource://services-sync/engines/passwords.sys.mjs");
+const { FormValidator } = ChromeUtils.importESModule("resource://services-sync/engines/forms.sys.mjs");
 
 // takes an array of objects who have no real properties but have a bunch of
 // getters on their prototypes, and returns an array of new objects that contain
@@ -93,7 +91,7 @@ const collectionComponentBuilders = {
   },
 
   async clients(provider, serverRecords) {
-    const { fxAccounts: legacyfxAccounts, getFxAccountsSingleton } = importLocal("resource://gre/modules/FxAccounts.jsm");
+    const { fxAccounts: legacyfxAccounts, getFxAccountsSingleton } = ChromeUtils.importESModule("resource://gre/modules/FxAccounts.sys.mjs");
     const fxAccounts = legacyfxAccounts || getFxAccountsSingleton();
     let fxaDevices = [];
     if (typeof fxAccounts.device == "object" && "recentDeviceList" in fxAccounts.device) {

--- a/src/provider.jsx
+++ b/src/provider.jsx
@@ -13,7 +13,6 @@ const { PrefCheckbox } = require("./config");
 const { Weave } = importLocal("resource://services-sync/main.js");
 
 const { CryptoWrapper, Collection } = importLocal("resource://services-sync/record.js");
-const { OS } = importLocal("resource://gre/modules/osfile.jsm");
 const { PlacesUtils } = importLocal("resource://gre/modules/PlacesUtils.jsm");
 
 const React = require("react");
@@ -191,7 +190,7 @@ class LocalProvider extends Provider {
       this.anonymize(ob);
     }
     let json = JSON.stringify(ob, undefined, 2); // pretty!
-    return OS.File.writeAtomic(path, json, {encoding: "utf-8", tmpPath: path + ".tmp"});
+    return IOUtils.writeUTF8(path, json);
   }
 
   /* Perform a quick-and-nasty anonymization of the data. Replaces many


### PR DESCRIPTION
About Sync is currently broken on nightly (and will be broken on beta soon). We need to use the new IOUtils instead of the now-removed OS.File.

https://github.com/mozilla/gecko-dev/blob/ae292ebba6074601b33fa983dd4e01ce6a1ec4ac/dom/docs/ioutils_migration.md

Has some nice documentation on the migration equivalents. I've almost fixed everything except downing a combined summary since there is no equivalent for `openUnique` or even `open`. Wanted to throw this one up early though.

