### PR TITLE
Change strict_min_version to not include 0a1

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,16 @@ The general process followed by the addons team is
 but at the current time, the maintainers of about-sync don't have the required
 permissions. Therefore, the process is:
 
-* Consider bumping the version in `package.json` - that's not strictly necessary
-  as the final version string will be something like `X.Y.Zbuildid20220601.073719`,
-  but it makes it easier to work out what's in a version.
+* Bump the version in `package.json`
+  > the final version string will be something like `X.Y.Zbuildid20220601.073719`
+
+* If needed, bump the `strict_min_version` in `manifest.json`. Ensure there is a matching version you're targeting in the [version list](https://addons.mozilla.org/api/v5/applications/firefox/)
+  > Must use an exact version, `{version_number}.*` are not allowed to be used
 
 * Find the exact github revision revision you want as the new build; usually current `main`.
   Ensure this revision is tested using the [testing process described above](#testing-a-xpi)
 
-* Join the #addons-pipeline slack channel, asking for a release to be built
-  specifying that exact revision.
+* Follow the [Mozilla Add-on Review Request Intake](https://mozilla-hub.atlassian.net/wiki/spaces/FDPDT/pages/10617933/Mozilla+Add-on+Review+Requests+Intake) instructions to create an issue that will kick off the process for an update.
 
 * You will be notified of an initial build, with will include a "dep-signing"
   task - however, this doesn't create the .xpi you can submit to AMO. Two

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
   "applications": {
     "gecko": {
       "id": "aboutsync@mhammond.github.com",
-      "strict_min_version": "114.0a1"
+      "strict_min_version": "114.0"
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aboutsync",
   "private": true,
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "About Sync Firefox addon",
   "scripts": {
     "build": "webpack --mode=production && web-ext build",


### PR DESCRIPTION
Running into issues updating the addon due to `114.0a1` apparently not existing in https://addons.mozilla.org/api/v5/applications/firefox/

which gives the error when uploading the new XPI
![Screenshot 2023-06-12 at 9 05 32 AM](https://github.com/mozilla-extensions/aboutsync/assets/436430/e8d94589-0703-4ba3-8912-50860ea0c68f)



Also bump the version just incase so the addon pipeline CI doesn't get confused.