### PR TITLE
Fix record editor error

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Once installed, type `about:sync` into the URL bar.
 
 # Running from source
 This is only possible in Nightly. To proceed, you must use `about:config` to
-set `extensions.experiments.enabled=true`.
+set `extensions.experiments.enabled=true` and `xpinstall.signatures.required=false`.
 * Clone the git repo locally.
 * Run `npm install` inside the repo.
 * Optionally, run `npm run dev` which should start a daemon which means any edits you
   make while Firefox is running should get picked up, and only need a "refresh" rather
   than a full browser restart to be seen.
-* In `about:debugging`, load the extension by selecting any file in the root directory (eg, `chrome.manifest`).
+* Visit `about:debugging` -> "This Nightly" -> "Load Temporary Addon", then select  any file in the root directory (eg, `chrome.manifest`).
 * Open `about:sync`
 
 ## Other help:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aboutsync",
-  "version": "0.21.0",
+  "version": "0.21.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aboutsync",
-      "version": "0.21.0",
+      "version": "0.21.2",
       "license": "MPL-2.0",
       "dependencies": {
         "classnames": "^2.2.5",

--- a/src/AboutSyncRecordEditor.jsx
+++ b/src/AboutSyncRecordEditor.jsx
@@ -233,8 +233,7 @@ class AboutSyncRecordEditor extends React.Component {
         </div>
         <ErrorDisplay error={this.state.error}
                       onClose={() => this.setState({error: null})}
-                      prefix="Error: "
-                      formatError={e => this.renderErrorMsg(e)}/>
+                      prefix="Error: "/>
         {this.state.error && (
           <div className="error-message">
             <button className="close-error"


### PR DESCRIPTION
The main problem being fixed here is that if the record editor sees an error, it fails to render it:

```
console.log: "Bad current record" null "{\n  \"bmkUri\": \"https://www.ozbargain.com.au/node/409403\",\n  \"dateAdded\": 1539657026637,\n  \"hasDupe\": true,\n  \"id\": \"--mM58RLNMB3\",\n  \"parentName\": \"OzB | New\",\n  \"parentid\": \"sqx21Cw3SEv9\",\n  \"title\": \"Men's 100% Cotton Jacket $11.98, T-shirt Fr $3.98, 80% Cotton Zipped Fleece $10 & More + $9.99 Shipped @ Sportdirect\",\n  \"type\": \"bookmark\",\n  \"extra\": {\"foo\": \"bar\"},\n}"
console.error: (new TypeError("e.renderErrorMsg is not a function", "chrome://aboutsync/content/build.js", 2))
console.error: "About Sync: Failed to fetch collection" (new TypeError("e.renderErrorMsg is not a function", "chrome://aboutsync/content/build.js", 2))
```

(in the above example, the problem was simply that the record was invalid json)