### PR TITLE
Update addon version to major.minor schema

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "description": "Show information about Firefox Sync.",
   "manifest_version": 2,
   "name": "About Sync",
-  "version": "0.0.0",
+  "version": "0.0",
   "homepage_url": "https://github.com/mozilla-extensions/aboutsync",
   "permissions": [
     "mozillaAddons"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aboutsync",
   "private": true,
-  "version": "0.24.0",
+  "version": "0.24",
   "description": "About Sync Firefox addon",
   "scripts": {
     "build": "webpack --mode=production && web-ext build",


### PR DESCRIPTION
@mozilla-extensions/releng

This change is needed for https://github.com/mozilla-extensions/xpi-manifest/pull/215

In [Bug 1793925](https://bugzilla.mozilla.org/show_bug.cgi?id=1793925), Firefox Desktop started to emit warnings when an extension's version doesn't match the format specified in the [MDN docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version#version_format).

To comply with this format, we need to drop the patch version on the add on pipeline web extensions.

The pipeline will now generate versions as `major.minor.date.time`