### PR TITLE
Update now that all builtin Firefox modules are eslint modules

### DIFF
--- a/ext_bootstrap.js
+++ b/ext_bootstrap.js
@@ -2,6 +2,8 @@ const { Log } = ChromeUtils.importESModule("resource://gre/modules/Log.sys.mjs")
 const { Weave } = ChromeUtils.importESModule("resource://services-sync/main.sys.mjs");
 const WeaveConstants = ChromeUtils.importESModule("resource://services-sync/constants.sys.mjs");
 const { XPCOMUtils } = ChromeUtils.importESModule("resource://gre/modules/XPCOMUtils.sys.mjs");
+const { STATUS_OK, MASTER_PASSWORD_LOCKED, LOGIN_FAILED_LOGIN_REJECTED, SERVER_MAINTENANCE, LOGIN_FAILED_NETWORK_ERROR } = ChromeUtils.importESModule("resource://services-sync/constants.sys.mjs");
+
 if (typeof console !== "object") {
   const { ConsoleAPI  } = ChromeUtils.importESModule("resource://gre/modules/Console.sys.mjs");
   var console = new ConsoleAPI();
@@ -70,12 +72,12 @@ function syncStatusObserver(subject, topic, data) {
 }
 
 function shouldReportError(data) {
-  if (Weave.Status.service == WeaveConstants.STATUS_OK ||
-      Weave.Status.login == WeaveConstants.MASTER_PASSWORD_LOCKED) {
+  if (Weave.Status.service == STATUS_OK ||
+      Weave.Status.login == MASTER_PASSWORD_LOCKED) {
     return false;
   }
 
-  if (Weave.Status.login == WeaveConstants.LOGIN_FAILED_LOGIN_REJECTED) {
+  if (Weave.Status.login == LOGIN_FAILED_LOGIN_REJECTED) {
     return true;
   }
 
@@ -92,8 +94,8 @@ function shouldReportError(data) {
     return false;
   }
 
-  return ![Weave.Status.login, Weave.Status.sync].includes(WeaveConstants.SERVER_MAINTENANCE) &&
-         ![Weave.Status.login, Weave.Status.sync].includes(WeaveConstants.LOGIN_FAILED_NETWORK_ERROR);
+  return ![Weave.Status.login, Weave.Status.sync].includes(SERVER_MAINTENANCE) &&
+         ![Weave.Status.login, Weave.Status.sync].includes(LOGIN_FAILED_NETWORK_ERROR);
 }
 
 let chromeHandle;

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
   "applications": {
     "gecko": {
       "id": "aboutsync@mhammond.github.com",
-      "strict_min_version": "114.0"
+      "strict_min_version": "136.0"
     }
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3656,10 +3656,11 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -6249,9 +6250,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {
@@ -6259,6 +6260,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },

--- a/webext/implementation.js
+++ b/webext/implementation.js
@@ -40,7 +40,9 @@ this.aboutsync = class extends ExtensionAPI {
                   console.error("FAILED to shutdown", ex);
                 }
                 ns = null;
-                Cu.unload(bootstrap);
+                // We can't do this any more - not sure it matters, but if it does, it would
+                // only be when upgrading to a new version?
+                // Cu.unload(bootstrap);
 
               }
             }


### PR DESCRIPTION
Includes a couple of fixes found by `npm audit` and lists that it's only available for 136 and up.