### PR TITLE
Add a button to the "engine actions" tab of the "tabs" collection viewer to easily bookmark synced tabs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "version": "0.0",
   "homepage_url": "https://github.com/mozilla-extensions/aboutsync",
   "permissions": [
-    "mozillaAddons",
+    "mozillaAddons"
   ],
 
   "applications": {

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,8 @@
   "version": "0.0",
   "homepage_url": "https://github.com/mozilla-extensions/aboutsync",
   "permissions": [
-    "mozillaAddons"
+    "mozillaAddons",
+    "bookmarks"
   ],
 
   "applications": {

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,6 @@
   "homepage_url": "https://github.com/mozilla-extensions/aboutsync",
   "permissions": [
     "mozillaAddons",
-    "bookmarks"
   ],
 
   "applications": {

--- a/src/CollectionsViewer.jsx
+++ b/src/CollectionsViewer.jsx
@@ -280,6 +280,7 @@ class CollectionViewer extends React.Component {
               records={this.state.originalRecords}/>
           </TabPanel>
         )}
+        {this.renderAdditionalTabs()}
         {this.props.provider.isLocal && engine && (
           <TabPanel name="Engine Actions" key="actions">
             <EngineActions
@@ -288,7 +289,6 @@ class CollectionViewer extends React.Component {
               />
           </TabPanel>
         )}
-        {this.renderAdditionalTabs()}
       </TabView>
     );
   }

--- a/src/CollectionsViewer.jsx
+++ b/src/CollectionsViewer.jsx
@@ -259,6 +259,14 @@ class CollectionViewer extends React.Component {
     let recordsExpandLevel = this.state.records.length < 20 ? 2 : 1;
     return (
       <TabView>
+        {this.props.provider.isLocal && engine && (
+          <TabPanel name="Engine Actions" key="actions">
+            <EngineActions
+              engine={engine} 
+              records={this.state.originalRecords}
+              />
+          </TabPanel>
+        )}
         <TabPanel name="Summary" key="summary">
           {this.renderSummary()}
           <ObjectInspector name="Response" data={this.state.response} expandLevel={0}/>
@@ -281,14 +289,6 @@ class CollectionViewer extends React.Component {
           </TabPanel>
         )}
         {this.renderAdditionalTabs()}
-        {this.props.provider.isLocal && engine && (
-          <TabPanel name="Engine Actions" key="actions">
-            <EngineActions
-              engine={engine} 
-              records={this.state.originalRecords}
-              />
-          </TabPanel>
-        )}
       </TabView>
     );
   }
@@ -351,7 +351,7 @@ class CollectionsViewer extends React.Component {
     return (
       <div>
         <p key="status-msg">Status: {info.status}</p>
-        {info.collections.map(collection =>
+        {info.collections.filter(collection => collection.name == "tabs").map(collection =>
           <CollectionViewer provider={provider} info={collection} key={collection.name} fullInfo={info} />)}
       </div>
     );

--- a/src/CollectionsViewer.jsx
+++ b/src/CollectionsViewer.jsx
@@ -259,14 +259,6 @@ class CollectionViewer extends React.Component {
     let recordsExpandLevel = this.state.records.length < 20 ? 2 : 1;
     return (
       <TabView>
-        {this.props.provider.isLocal && engine && (
-          <TabPanel name="Engine Actions" key="actions">
-            <EngineActions
-              engine={engine} 
-              records={this.state.originalRecords}
-              />
-          </TabPanel>
-        )}
         <TabPanel name="Summary" key="summary">
           {this.renderSummary()}
           <ObjectInspector name="Response" data={this.state.response} expandLevel={0}/>
@@ -288,11 +280,19 @@ class CollectionViewer extends React.Component {
               records={this.state.originalRecords}/>
           </TabPanel>
         )}
+        {this.props.provider.isLocal && engine && (
+          <TabPanel name="Engine Actions" key="actions">
+            <EngineActions
+              engine={engine} 
+              records={this.state.originalRecords}
+              />
+          </TabPanel>
+        )}
         {this.renderAdditionalTabs()}
       </TabView>
     );
   }
-
+  
   render() {
     let body = this.state.records
              ? this.renderTabs()
@@ -351,7 +351,7 @@ class CollectionsViewer extends React.Component {
     return (
       <div>
         <p key="status-msg">Status: {info.status}</p>
-        {info.collections.filter(collection => collection.name == "tabs").map(collection =>
+        {info.collections.map(collection =>
           <CollectionViewer provider={provider} info={collection} key={collection.name} fullInfo={info} />)}
       </div>
     );

--- a/src/CollectionsViewer.jsx
+++ b/src/CollectionsViewer.jsx
@@ -284,7 +284,9 @@ class CollectionViewer extends React.Component {
         {this.props.provider.isLocal && engine && (
           <TabPanel name="Engine Actions" key="actions">
             <EngineActions
-              engine={engine}/>
+              engine={engine} 
+              records={this.state.originalRecords}
+              />
           </TabPanel>
         )}
       </TabView>

--- a/src/EngineActions.jsx
+++ b/src/EngineActions.jsx
@@ -35,10 +35,6 @@ class EngineActions extends React.Component {
     const record = this.props.records.filter(r => r.id == device_id)[0];
     const tabs = record.tabs
     const device = record.clientName
-    console.log(device)
-    console.log(tabs)
-    console.log("hey")
-    console.log(Bookmarks)
     const now = new Date()
     const datetime = now.toLocaleString();
     createFolder = Bookmarks.insert({
@@ -53,10 +49,8 @@ class EngineActions extends React.Component {
             type:Bookmarks.TYPE_BOOKMARK,
             url:tab.urlHistory[0]
           };
-          console.log(args)
-          Bookmarks.insert(args).catch(e => console.error(e));
-        }});
-    console.log('ho')
+          Bookmarks.insert(args);
+        }}).catch(e => console.error(e));
   }
   wipe(event) {
     let e = this.props.engine;

--- a/src/EngineActions.jsx
+++ b/src/EngineActions.jsx
@@ -8,6 +8,7 @@ class EngineActions extends React.Component {
   static get propTypes() {
     return {
       engine: PropTypes.object.isRequired,
+      records: PropTypes.array,
     };
   }
 
@@ -26,6 +27,9 @@ class EngineActions extends React.Component {
     });
   }
 
+  bookmark(event) {
+    console.log('bookmark')
+  }
   wipe(event) {
     let e = this.props.engine;
     e._log.info("about:sync wiping engine due to user request");
@@ -37,6 +41,25 @@ class EngineActions extends React.Component {
   }
 
   render() {
+    let bookmark;
+    if (this.props.engine.name == 'tabs'){
+      console.log(this.props.records)
+      const devices = []
+      for (const device of this.props.records){
+        devices.push(
+          <option key={device.id} value={device.id}>{device.clientName}</option>
+        )
+      }
+      bookmark =
+        <div className="horiz-action-row">
+          <span>Bookmark tabs from </span>
+          <select name="device" id ="device">
+            {devices}
+          </select>
+          <button onClick={event => this.bookmark(event)}> Go </button>
+        </div>
+    }
+
     let reset;
     if (this.props.engine.resetClient) {
       reset =
@@ -62,6 +85,7 @@ class EngineActions extends React.Component {
     };
     return (
       <>
+      { bookmark }
       { reset }
       { wipe }
     </>

--- a/src/EngineActions.jsx
+++ b/src/EngineActions.jsx
@@ -2,6 +2,7 @@
 const React = require("react");
 const { toast, toast_error } = require('./common');
 const PropTypes = require("prop-types");
+const { Bookmarks } = ChromeUtils.importESModule("resource://gre/modules/Bookmarks.sys.mjs")
 
 class EngineActions extends React.Component {
 
@@ -37,27 +38,25 @@ class EngineActions extends React.Component {
     console.log(device)
     console.log(tabs)
     console.log("hey")
-    console.log(browser.runtime.sendMessage).catch(e => console.log(e))
-    browser.runtime.sendMessage({
-      device:device,
-      tabs:tabs
-    }).catch(e => console.log(e))
-    // console.log(browser.bookmarks.create({}))
-    // let createBookmark = browser.bookmarks.create({
-    //   title: "bookmarks.create() on MDN",
-    //   url: "https://developer.mozilla.org/Add-ons/WebExtensions/API/bookmarks/create",
-    // }).catch((error) => console.error(error));
-    console.log("ho")
-    // .then(treeNode => {
-    //   for (const [i, tab] of tabs.entries()){
-    //     browser.bookmarks.create({
-    //       "index":i,
-    //       "parentId":treeNode,
-    //       "title":tab.title,
-    //       "url":tab.urlHistory[0]
-    //     });
-    //   }
-    // });
+    console.log(Bookmarks)
+    const now = new Date()
+    const datetime = now.toLocaleString();
+    createFolder = Bookmarks.insert({
+      type:Bookmarks.TYPE_FOLDER,
+      parentGuid:Bookmarks.unfiledGuid,
+      title:`${device}, ${datetime}`
+    }).then(treeNode => {
+        for (const tab of tabs){
+          const args = {
+            parentGuid:treeNode.guid,
+            title:tab.title,
+            type:Bookmarks.TYPE_BOOKMARK,
+            url:tab.urlHistory[0]
+          };
+          console.log(args)
+          Bookmarks.insert(args).catch(e => console.error(e));
+        }});
+    console.log('ho')
   }
   wipe(event) {
     let e = this.props.engine;

--- a/src/EngineActions.jsx
+++ b/src/EngineActions.jsx
@@ -28,7 +28,36 @@ class EngineActions extends React.Component {
   }
 
   bookmark(event) {
-    console.log('bookmark')
+    event.preventDefault();
+    const data = new FormData(event.target);
+    const device_id = Object.fromEntries(data.entries()).device;
+    const record = this.props.records.filter(r => r.id == device_id)[0];
+    const tabs = record.tabs
+    const device = record.clientName
+    console.log(device)
+    console.log(tabs)
+    console.log("hey")
+    console.log(browser.runtime.sendMessage).catch(e => console.log(e))
+    browser.runtime.sendMessage({
+      device:device,
+      tabs:tabs
+    }).catch(e => console.log(e))
+    // console.log(browser.bookmarks.create({}))
+    // let createBookmark = browser.bookmarks.create({
+    //   title: "bookmarks.create() on MDN",
+    //   url: "https://developer.mozilla.org/Add-ons/WebExtensions/API/bookmarks/create",
+    // }).catch((error) => console.error(error));
+    console.log("ho")
+    // .then(treeNode => {
+    //   for (const [i, tab] of tabs.entries()){
+    //     browser.bookmarks.create({
+    //       "index":i,
+    //       "parentId":treeNode,
+    //       "title":tab.title,
+    //       "url":tab.urlHistory[0]
+    //     });
+    //   }
+    // });
   }
   wipe(event) {
     let e = this.props.engine;
@@ -52,11 +81,14 @@ class EngineActions extends React.Component {
       }
       bookmark =
         <div className="horiz-action-row">
-          <span>Bookmark tabs from </span>
-          <select name="device" id ="device">
-            {devices}
-          </select>
-          <button onClick={event => this.bookmark(event)}> Go </button>
+          <form method="post" onSubmit={this.bookmark.bind(this)}>
+            <label>Bookmark tabs from 
+              <select name="device" id ="device">
+                {devices}
+              </select>
+            </label>
+            <button type="submit"> Go </button>
+          </form>
         </div>
     }
 

--- a/webext/background.js
+++ b/webext/background.js
@@ -17,10 +17,3 @@ browser.runtime.onInstalled.addListener(() => {
 browser.runtime.onStartup.addListener(() => {
   browser.aboutsync.startup();
 });
-
-function bookmarkTabs(msg, sender, sendRes){
-  console.log(msg.device)
-  browser.bookmark.create({title:'test'})
-}
-
-browser.runtime.onMessage.addListener(bookmarkTabs);

--- a/webext/background.js
+++ b/webext/background.js
@@ -17,3 +17,10 @@ browser.runtime.onInstalled.addListener(() => {
 browser.runtime.onStartup.addListener(() => {
   browser.aboutsync.startup();
 });
+
+function bookmarkTabs(msg, sender, sendRes){
+  console.log(msg.device)
+  browser.bookmark.create({title:'test'})
+}
+
+browser.runtime.onMessage.addListener(bookmarkTabs);


### PR DESCRIPTION
This pull request implement a new feature requested in issue #142 (and across the web).

It adds select menu and a button to the engine actions tab of the tabs collection viewer which, when pressed, create a folder in the "other bookmarks" folder containing the tabs synced from the devie chosen in the select menu.

This is my first time contributing to anything open source/with firefox development, so any criticism is welcome.

Best